### PR TITLE
Add retry logic to watch requests

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -210,6 +210,16 @@ var _ = Describe("Test the client", Ordered, func() {
 		Eventually(reconcilerObj.ResultsChan, "5s").Should(HaveLen(1))
 	})
 
+	It("Ensures the watches restart on a Kubernetes API outage", func() {
+		By("Restarting the Kubernetes API server")
+		Expect(testEnv.ControlPlane.APIServer.Stop()).To(BeNil())
+		Expect(testEnv.ControlPlane.APIServer.Start()).To(BeNil())
+
+		By("Checking that a reconcile for each object was called")
+		// This is a longer timeout to account for the API server needing to start up.
+		Eventually(reconcilerObj.ResultsChan, "60s").Should(HaveLen(2))
+	})
+
 	It("Verifies the watch count", func() {
 		Expect(dynamicWatcher.GetWatchCount()).To(Equal(uint(2)))
 	})

--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -5,6 +5,7 @@ package client
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,12 +37,16 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping the test environment")
-	testEnv = &envtest.Environment{}
+	testEnv = &envtest.Environment{ControlPlaneStopTimeout: time.Minute * 3}
 
 	var err error
 	k8sConfig, err = testEnv.Start()
 	Expect(err).To(BeNil())
 	Expect(k8sConfig).NotTo(BeNil())
+
+	// Required for tests that involve restarting the test environment since new certs are generated.
+	k8sConfig.TLSClientConfig.Insecure = true
+	k8sConfig.TLSClientConfig.CAData = nil
 
 	k8sClient, err = kubernetes.NewForConfig(k8sConfig)
 	Expect(err).To(BeNil())


### PR DESCRIPTION
This starts using the client-go RetryWatcher API which should handle almost all network flakes seamlessly on the watch requests. One major exception is when the last resourceVersion on the list request that the RetryWatcher API is aware of no longer exists on the Kubernetes cluster. A new watch request must be created in that case from the latest resourceVersion.

Alternatively, the informer API could have been used, but this would involve caching the actual objects, which is not desired for scale.

Relates:
https://issues.redhat.com/browse/ACM-2449