### PR TITLE
Disregard namespace on cluster-scoped watched objects

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -127,7 +127,9 @@ var _ = Describe("Test the client", Ordered, func() {
 
 		watchedObjIDs = []ObjectIdentifier{}
 		for _, watchedObj := range watched {
-			watchedObjIDs = append(watchedObjIDs, toObjectIdentifer(watchedObj))
+			id := toObjectIdentifer(watchedObj)
+			id.Namespace = namespace // ensure namespace is set, even (possibly "incorrectly") on cluster-scoped objects
+			watchedObjIDs = append(watchedObjIDs, id)
 		}
 
 		go func() {
@@ -337,7 +339,9 @@ var _ = Describe("Test the client clean up", Ordered, func() {
 	It("Verifies the client cleans up watches", func() {
 		watchedObjIDs := []ObjectIdentifier{}
 		for _, watchedObj := range watched {
-			watchedObjIDs = append(watchedObjIDs, toObjectIdentifer(watchedObj))
+			id := toObjectIdentifer(watchedObj)
+			id.Namespace = namespace // ensure namespace is set, even (possibly "incorrectly") on cluster-scoped objects
+			watchedObjIDs = append(watchedObjIDs, id)
 		}
 
 		By("Adding the watcher with two watched objects")

--- a/client/source_test.go
+++ b/client/source_test.go
@@ -46,7 +46,9 @@ var _ = Describe("Test the controller-runtime source wrapper", func() {
 
 		watchedObjIDs = []ObjectIdentifier{}
 		for _, watchedObj := range watched {
-			watchedObjIDs = append(watchedObjIDs, toObjectIdentifer(watchedObj))
+			id := toObjectIdentifer(watchedObj)
+			id.Namespace = namespace // ensure namespace is set, even (possibly "incorrectly") on cluster-scoped objects
+			watchedObjIDs = append(watchedObjIDs, id)
 		}
 
 		go func() {


### PR DESCRIPTION
It is usual for namespaces to be ignored on cluster-scoped resources, but in this library, "incorrectly" specifying a namespace causes an error. The library already has the API information and can determine if the resource is cluster-scoped, preventing the error.

This error is part of the issue in https://issues.redhat.com/browse/ACM-5547