### PR TITLE
Add ability to watch a selector

### DIFF
--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -35,6 +36,8 @@ func TestClient(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	format.TruncatedDiff = false
 
 	By("bootstrapping the test environment")
 	testEnv = &envtest.Environment{ControlPlaneStopTimeout: time.Minute * 3}


### PR DESCRIPTION
Instead of just a named object, this allows a user to watch a list with a label selector in the same kind of API. The new selector field in an ObjectIdentifier is the string representation of a LabelSelector.

This implementation only de-duplicates watches with the exact same selector string - there might be multiple equivalent representations for a selector, and the library does not attempt to identify these. It also does not de-duplicate watches or events when a watcher watches both a selector and a specifically named object that might be covered by that selector.

Refs:
 - https://issues.redhat.com/browse/ACM-6428