### PR TITLE
Add caching of watched objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export GOPATH ?= $(GOPATH_DEFAULT)
 GOBIN_DEFAULT := $(GOPATH)/bin
 export GOBIN ?= $(GOBIN_DEFAULT)
 export PATH := $(LOCAL_BIN):$(GOBIN):$(PATH)
-TESTARGS_DEFAULT := "-v"
+TESTARGS_DEFAULT := -v
 export TESTARGS ?= $(TESTARGS_DEFAULT)
 
 include build/common/Makefile.common.mk

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - cyclop
     - depguard
     - dupl
+    - dupword # false positive on the tested output for ExampleDynamicWatcher_Get
     - funlen
     - exhaustruct
     - exhaustivestruct

--- a/client/cache.go
+++ b/client/cache.go
@@ -1,0 +1,313 @@
+// Copyright Contributors to the Open Cluster Management project
+package client
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/klog"
+)
+
+var ErrNoCacheEntry = errors.New("there was no populated cache entry")
+
+// ObjectCache provides a concurrency safe cache of unstructured objects. Additionally, it's able to convert GVKs to
+// GVRs and cache the results.
+type ObjectCache interface { //nolint: interfacebloat
+	// Get returns the object from the cache. A nil value can be returned to indicate a not found is cached. The error
+	// ErrNoCacheEntry is returned if there is no cache entry at all.
+	Get(gvk schema.GroupVersionKind, namespace string, name string) (*unstructured.Unstructured, error)
+	// List returns the objects from the cache, which can be an empty list. The error ErrNoCacheEntry is returned if
+	// there is no cache entry.
+	List(gvk schema.GroupVersionKind, namespace string, selector labels.Selector) ([]unstructured.Unstructured, error)
+	// FromObjectIdentifier returns the objects from the cache, which can be an empty list, based on the input object
+	// identifier. The error ErrNoCacheEntry is returned if there is no cache entry at all.
+	FromObjectIdentifier(objID ObjectIdentifier) ([]unstructured.Unstructured, error)
+	// CacheList will cache a list of objects for the list query.
+	CacheList(
+		gvk schema.GroupVersionKind, namespace string, selector labels.Selector, objects []unstructured.Unstructured,
+	)
+	// CacheObject allows to cache an object. The input object can be nil to indicate a cached not found result.
+	CacheObject(gvk schema.GroupVersionKind, namespace string, name string, object *unstructured.Unstructured)
+	// CacheFromObjectIdentifier will cache a list of objects for the input object identifier.
+	CacheFromObjectIdentifier(objID ObjectIdentifier, objects []unstructured.Unstructured)
+	// UncacheObject will entirely remove the cache entry of the object.
+	UncacheObject(gvk schema.GroupVersionKind, namespace string, name string)
+	// UncacheObject will entirely remove the cache entries for the list query.
+	UncacheList(gvk schema.GroupVersionKind, namespace string, selector labels.Selector)
+	// UncacheObject will entirely remove the cache entries for the object identifier.
+	UncacheFromObjectIdentifier(objID ObjectIdentifier)
+	// GVKToGVR will convert a GVK to a GVR and cache the result for a default of 10 minutes (configurable) when found,
+	// and not cache failed conversions by default (configurable).
+	GVKToGVR(gvk schema.GroupVersionKind) (ScopedGVR, error)
+	// Clear will entirely clear the cache.
+	Clear()
+}
+
+type lockedGVR struct {
+	lock    *sync.RWMutex
+	gvr     *ScopedGVR
+	expires time.Time
+}
+
+func (l *lockedGVR) isExpired() bool {
+	return time.Now().After(l.expires)
+}
+
+type objectCache struct {
+	cache           *sync.Map
+	discoveryClient *discovery.DiscoveryClient
+	// gvkToGVRCache is used as a cache of GVK to GVR mappings. The cache entries automatically expire after 10 minutes.
+	gvkToGVRCache *sync.Map
+	options       ObjectCacheOptions
+}
+
+type ObjectCacheOptions struct {
+	// The time for a GVK to GVR conversion cache entry to be considered fresh (not expired). This excludes missing API
+	// resources, which is configured by MissingAPIResourceCacheTTL. The default value is 10 minutes.
+	GVKToGVRCacheTTL time.Duration
+	// The time for a failed GVK to GVR conversion to not be retried. The default behavior is to not cache failures.
+	// Setting this can be useful if you don't want to continuously query the Kubernetes API if a CRD is missing.
+	MissingAPIResourceCacheTTL time.Duration
+}
+
+// NewObjectCache will create an object cache with the input discovery client.
+func NewObjectCache(discoveryClient *discovery.DiscoveryClient, options ObjectCacheOptions) ObjectCache {
+	if options.GVKToGVRCacheTTL == 0 {
+		options.GVKToGVRCacheTTL = 10 * time.Minute
+	}
+
+	return &objectCache{
+		cache:           &sync.Map{},
+		gvkToGVRCache:   &sync.Map{},
+		discoveryClient: discoveryClient,
+	}
+}
+
+// Get returns the object from the cache. A nil value can be returned to indicate a not found is cached. The error
+// ErrNoCacheEntry is returned if there is no cache entry at all.
+func (o *objectCache) Get(
+	gvk schema.GroupVersionKind, namespace string, name string,
+) (*unstructured.Unstructured, error) {
+	objID := ObjectIdentifier{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	result, err := o.FromObjectIdentifier(objID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result) == 0 {
+		return nil, nil
+	}
+
+	return &result[0], nil
+}
+
+// List returns the objects from the cache, which can be an empty list. The error ErrNoCacheEntry is returned if
+// there is no cache entry.
+func (o *objectCache) List(
+	gvk schema.GroupVersionKind, namespace string, selector labels.Selector,
+) ([]unstructured.Unstructured, error) {
+	if selector == nil {
+		selector = labels.NewSelector()
+	}
+
+	objID := ObjectIdentifier{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: namespace,
+		Selector:  selector.String(),
+	}
+
+	return o.FromObjectIdentifier(objID)
+}
+
+// CacheList will cache a list of objects for the list query.
+func (o *objectCache) CacheList(
+	gvk schema.GroupVersionKind, namespace string, selector labels.Selector, objects []unstructured.Unstructured,
+) {
+	if selector == nil {
+		selector = labels.NewSelector()
+	}
+
+	objID := ObjectIdentifier{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: namespace,
+		Selector:  selector.String(),
+	}
+
+	o.CacheFromObjectIdentifier(objID, objects)
+}
+
+// FromObjectIdentifier returns the objects from the cache, which can be an empty list, based on the input object
+// identifier. The error ErrNoCacheEntry is returned if there is no cache entry at all.
+func (o *objectCache) FromObjectIdentifier(objID ObjectIdentifier) ([]unstructured.Unstructured, error) {
+	loadedResult, loaded := o.cache.Load(objID)
+	if !loaded {
+		return nil, fmt.Errorf("%w for %s", ErrNoCacheEntry, objID)
+	}
+
+	// Type assertion checks aren't needed since this is the only method that stores data.
+	result := loadedResult.([]unstructured.Unstructured)
+
+	return result, nil
+}
+
+// CacheObject allows to cache an object. The input object can be nil to indicate a cached not found result.
+func (o *objectCache) CacheObject(
+	gvk schema.GroupVersionKind, namespace string, name string, object *unstructured.Unstructured,
+) {
+	objID := ObjectIdentifier{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	o.CacheFromObjectIdentifier(objID, []unstructured.Unstructured{*object})
+}
+
+// CacheFromObjectIdentifier will cache a list of objects for the input object identifier.
+func (o *objectCache) CacheFromObjectIdentifier(objID ObjectIdentifier, objects []unstructured.Unstructured) {
+	o.cache.Store(objID, objects)
+}
+
+// UncacheObject will entirely remove the cache entry of the object.
+func (o *objectCache) UncacheObject(gvk schema.GroupVersionKind, namespace string, name string) {
+	objID := ObjectIdentifier{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	o.UncacheFromObjectIdentifier(objID)
+}
+
+// UncacheObject will entirely remove the cache entries for the list query.
+func (o *objectCache) UncacheList(gvk schema.GroupVersionKind, namespace string, selector labels.Selector) {
+	if selector == nil {
+		selector = labels.NewSelector()
+	}
+
+	objID := ObjectIdentifier{
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
+		Namespace: namespace,
+		Selector:  selector.String(),
+	}
+
+	o.UncacheFromObjectIdentifier(objID)
+}
+
+// UncacheObject will entirely remove the cache entries for the object identifier.
+func (o *objectCache) UncacheFromObjectIdentifier(objID ObjectIdentifier) {
+	o.cache.Delete(objID)
+}
+
+// GVKToGVR will convert a GVK to a GVR and cache the result for a default of 10 minutes (configurable) when found, and
+// not cache failed conversions by default (configurable).
+func (o *objectCache) GVKToGVR(gvk schema.GroupVersionKind) (ScopedGVR, error) {
+	now := time.Now()
+
+	lockedGVRObj := &lockedGVR{lock: &sync.RWMutex{}, expires: now.Add(o.options.GVKToGVRCacheTTL)}
+	lockedGVRObj.lock.Lock()
+
+	loadedLockedGVRObj, loaded := o.gvkToGVRCache.LoadOrStore(gvk, lockedGVRObj)
+	if loaded {
+		// If the value was loaded (not stored), there means there is a cached value or it is being populated.
+		lockedGVRObj = loadedLockedGVRObj.(*lockedGVR)
+		lockedGVRObj.lock.RLock()
+
+		if !lockedGVRObj.isExpired() {
+			lockedGVRObj.lock.RUnlock()
+			// If stored but nil, this means the previous call failed.
+			if lockedGVRObj.gvr == nil {
+				return ScopedGVR{}, ErrNoVersionedResource
+			}
+
+			return *lockedGVRObj.gvr, nil
+		}
+
+		// The cache is expired, get a write lock to update the entry.
+		lockedGVRObj.lock.RUnlock()
+		lockedGVRObj.lock.Lock()
+	}
+
+	defer lockedGVRObj.lock.Unlock()
+
+	groupVersion := gvk.GroupVersion().String()
+
+	resources, err := o.discoveryClient.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Infof("The group version was not found: %s", groupVersion)
+
+			lockedGVRObj.expires = now.Add(o.options.MissingAPIResourceCacheTTL)
+
+			return ScopedGVR{}, ErrNoVersionedResource
+		}
+
+		return ScopedGVR{}, err
+	}
+
+	for _, apiRes := range resources.APIResources {
+		if apiRes.Kind == gvk.Kind {
+			klog.V(2).Infof("Found the API resource: %v", apiRes)
+
+			gv := gvk.GroupVersion()
+
+			gvr := ScopedGVR{
+				GroupVersionResource: schema.GroupVersionResource{
+					Group:    gv.Group,
+					Version:  gv.Version,
+					Resource: apiRes.Name,
+				},
+				Namespaced: apiRes.Namespaced,
+			}
+
+			lockedGVRObj.gvr = &gvr
+
+			return gvr, nil
+		}
+	}
+
+	klog.V(2).Infof("The APIResource for the GVK wasn't found: %v", gvk)
+
+	lockedGVRObj.expires = now.Add(o.options.MissingAPIResourceCacheTTL)
+
+	return ScopedGVR{}, ErrNoVersionedResource
+}
+
+// Clear will entirely clear the cache.
+func (o *objectCache) Clear() {
+	o.cache.Range(func(key, value any) bool {
+		o.cache.Delete(key)
+
+		return true
+	})
+
+	o.gvkToGVRCache.Range(func(key, value any) bool {
+		o.gvkToGVRCache.Delete(key)
+
+		return true
+	})
+}

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -1,0 +1,145 @@
+// Copyright Contributors to the Open Cluster Management project
+package client
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+var _ = Describe("Test the cache", Ordered, func() {
+	var cache ObjectCache
+	configMapGVK := schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "ConfigMap",
+	}
+
+	BeforeEach(func() {
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(k8sConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		cache = NewObjectCache(discoveryClient, ObjectCacheOptions{})
+	})
+
+	It("Returns an error for queries with no cache entries", func() {
+		object, err := cache.Get(configMapGVK, "default", "something")
+		Expect(err).To(MatchError(ErrNoCacheEntry))
+		Expect(object).To(BeNil())
+
+		objects, err := cache.List(configMapGVK, "default", nil)
+		Expect(err).To(MatchError(ErrNoCacheEntry))
+		Expect(objects).To(BeNil())
+	})
+
+	It("Caches a get object", func() {
+		object := unstructured.Unstructured{}
+		object.SetName("cached-object1")
+		cache.CacheObject(configMapGVK, "default", "something", &object)
+
+		cachedObject, err := cache.Get(configMapGVK, "default", "something")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*cachedObject).To(Equal(object))
+
+		// Update the cache and get again
+		object.SetLabels(map[string]string{"raleigh": "nc"})
+		cache.CacheObject(configMapGVK, "default", "something", &object)
+
+		cachedObject, err = cache.Get(configMapGVK, "default", "something")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*cachedObject).To(Equal(object))
+
+		cache.UncacheObject(configMapGVK, "default", "something")
+		cachedObject, err = cache.Get(configMapGVK, "default", "something")
+		Expect(err).To(MatchError(ErrNoCacheEntry))
+		Expect(cachedObject).To(BeNil())
+	})
+
+	It("Caches a list query result", func() {
+		object1 := unstructured.Unstructured{}
+		object1.SetName("cached-object1")
+		object2 := unstructured.Unstructured{}
+		object2.SetName("cached-object2")
+		cache.CacheList(configMapGVK, "default", nil, []unstructured.Unstructured{object1, object2})
+
+		cachedObjects, err := cache.List(configMapGVK, "default", nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cachedObjects).To(HaveLen(2))
+		Expect(cachedObjects[0]).To(Equal(object1))
+		Expect(cachedObjects[1]).To(Equal(object2))
+
+		// Simulate an object being deleted
+		cache.CacheList(configMapGVK, "default", nil, []unstructured.Unstructured{object2})
+
+		cachedObjects, err = cache.List(configMapGVK, "default", nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cachedObjects).To(HaveLen(1))
+		Expect(cachedObjects[0]).To(Equal(object2))
+
+		cache.UncacheList(configMapGVK, "default", nil)
+		cachedObjects, err = cache.List(configMapGVK, "default", nil)
+		Expect(err).To(MatchError(ErrNoCacheEntry))
+		Expect(cachedObjects).To(BeNil())
+	})
+
+	It("Can convert a GVK to a GVR", func() {
+		gvr, err := cache.GVKToGVR(configMapGVK)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gvr.Resource).To(Equal("configmaps"))
+	})
+
+	It("Fails when a resource is invalid when converting a GVK to a GVR", func() {
+		// Invalid group
+		_, err := cache.GVKToGVR(schema.GroupVersionKind{Group: "Italian Food", Version: "v1", Kind: "Spaghetti"})
+		Expect(err).To(MatchError(ErrNoVersionedResource))
+
+		// Valid group but invalid kind
+		_, err = cache.GVKToGVR(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Spaghetti"})
+		Expect(err).To(MatchError(ErrNoVersionedResource))
+	})
+
+	It("Can have its cache cleared", func() {
+		gvr, err := cache.GVKToGVR(configMapGVK)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gvr.Resource).To(Equal("configmaps"))
+
+		object1 := unstructured.Unstructured{}
+		object1.SetName("cached-object1")
+		object2 := unstructured.Unstructured{}
+		object2.SetName("cached-object2")
+		cache.CacheObject(configMapGVK, "default", "something1", &object1)
+		cache.CacheObject(configMapGVK, "default", "something2", &object2)
+
+		cache.Clear()
+
+		cachedObject1, err := cache.Get(configMapGVK, "default", "something1")
+		Expect(err).To(MatchError(ErrNoCacheEntry))
+		Expect(cachedObject1).To(BeNil())
+
+		cachedObject2, err := cache.Get(configMapGVK, "default", "something2")
+		Expect(err).To(MatchError(ErrNoCacheEntry))
+		Expect(cachedObject2).To(BeNil())
+	})
+
+	It("Can have an empty cache entry", func() {
+		cache.CacheList(configMapGVK, "default", nil, nil)
+
+		cachedObjects, err := cache.List(configMapGVK, "default", nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cachedObjects).To(BeEmpty())
+
+		obj := ObjectIdentifier{
+			Group:     "",
+			Version:   "v1",
+			Kind:      "ConfigMap",
+			Namespace: "test-ns",
+			Name:      "watcher",
+		}
+		cache.CacheFromObjectIdentifier(obj, nil)
+
+		cachedObject, err := cache.Get(configMapGVK, "test-ns", "watcher")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cachedObject).To(BeNil())
+	})
+})

--- a/client/client_example_test.go
+++ b/client/client_example_test.go
@@ -22,7 +22,10 @@ import (
 
 type reconciler struct{}
 
-func (r *reconciler) Reconcile(_ context.Context, _ client.ObjectIdentifier) (reconcile.Result, error) {
+func (r *reconciler) Reconcile(_ context.Context, watcher client.ObjectIdentifier) (reconcile.Result, error) {
+	//nolint: forbidigo
+	fmt.Printf("An object that this object (%s) was watching was updated\n", watcher)
+
 	return reconcile.Result{}, nil
 }
 
@@ -271,7 +274,9 @@ func ExampleDynamicWatcher_Get() { //nolint: nosnakecase
 	}()
 
 	// Create the dynamic watcher with the cache enabled.
-	dynamicWatcher, err := client.New(k8sConfig, &reconciler{}, &client.Options{EnableCache: true})
+	dynamicWatcher, err := client.New(
+		k8sConfig, &reconciler{}, &client.Options{DisableInitialReconcile: true, EnableCache: true},
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/client/source.go
+++ b/client/source.go
@@ -43,7 +43,7 @@ func (t *ControllerRuntimeSourceReconciler) Reconcile(
 ) {
 	watcherObj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": watcher.Group + "/" + watcher.Version,
+			"apiVersion": watcher.GroupVersionKind().GroupVersion().String(),
 			"kind":       watcher.Kind,
 			"metadata": map[string]interface{}{
 				"name":      watcher.Name,

--- a/client/source_test.go
+++ b/client/source_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Test the controller-runtime source wrapper", func() {
 
 		ctrlRuntimeReconciler = controllerRuntimeReconciler{}
 		reconciler, sourceChan := NewControllerRuntimeSource()
-		watcher, watched, dynamicWatcher = getDynamicWatcher(ctxTest, reconciler)
+		watcher, watched, dynamicWatcher = getDynamicWatcher(ctxTest, reconciler, nil)
 
 		watchedObjIDs = []ObjectIdentifier{}
 		for _, watchedObj := range watched {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/stolostron/kubernetes-dependency-watches
 go 1.20
 
 require (
-	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
 	k8s.io/api v0.26.1
@@ -54,7 +53,6 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	golang.org/x/term v0.7.0 // indirect
 	golang.org/x/text v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
-github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -399,8 +397,6 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
-golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
The second commit adds an option to disable the initial reconcile when a watch is added. This often won't be needed when using the caching query API.

I recommend looking at the example first.

Related:
https://issues.redhat.com/browse/ACM-7398
https://issues.redhat.com/browse/ACM-7402