### PR TITLE
Deep copy by default

### DIFF
--- a/client/cache.go
+++ b/client/cache.go
@@ -87,6 +87,7 @@ func NewObjectCache(discoveryClient *discovery.DiscoveryClient, options ObjectCa
 		cache:           &sync.Map{},
 		gvkToGVRCache:   &sync.Map{},
 		discoveryClient: discoveryClient,
+		options:         options,
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -57,7 +57,8 @@ type Options struct {
 	// DisableInitialReconcile causes the initial reconcile from the list request before the watch to not cause a
 	// reconcile. This is useful if you are exclusively using the caching query API.
 	DisableInitialReconcile bool
-	// Options for how long to cache GVK to GVR conversions.
+	// Options for how long to cache GVK to GVR conversions, and whether to disable the DeepCopy when retrieving items
+	// from the cache.
 	ObjectCacheOptions ObjectCacheOptions
 }
 


### PR DESCRIPTION
Not DeepCopying can save some resources in some situations, but is also a common way to introduce hard-to-find bugs, since items in the cache can then mutate unexpectedly. This library now follows the pattern from controller-runtime, which does a DeepCopy by default, which can be disabled with an option when creating the client.
