### PR TITLE
Stop caching managedFields and last-applied-configuration

### DIFF
--- a/client/cache.go
+++ b/client/cache.go
@@ -196,8 +196,17 @@ func (o *objectCache) CacheObject(
 	o.CacheFromObjectIdentifier(objID, []unstructured.Unstructured{*object})
 }
 
-// CacheFromObjectIdentifier will cache a list of objects for the input object identifier.
+// CacheFromObjectIdentifier will cache a list of objects for the input object identifier. The metadata.managedFields
+// and metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"] values are automatically removed to
+// save on memory.
 func (o *objectCache) CacheFromObjectIdentifier(objID ObjectIdentifier, objects []unstructured.Unstructured) {
+	for i := range objects {
+		unstructured.RemoveNestedField(objects[i].Object, "metadata", "managedFields")
+		unstructured.RemoveNestedField(
+			objects[i].Object, "metadata", "annotations", "kubectl.kubernetes.io/last-applied-configuration",
+		)
+	}
+
 	o.cache.Store(objID, objects)
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1023,6 +1023,8 @@ var _ = Describe("Test the client query API", Ordered, func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
+		Expect(cachedObj1.GetManagedFields()).To(BeEmpty())
+		Expect(cachedObj1.GetAnnotations()["kubectl.kubernetes.io/last-applied-configuration"]).To(BeEmpty())
 		Expect(cachedObj1.GroupVersionKind()).To(Equal(watched[0].GroupVersionKind()))
 		Expect(cachedObj1.GetNamespace()).To(Equal(watched[0].GetNamespace()))
 		Expect(cachedObj1.GetName()).To(Equal(watched[0].GetName()))


### PR DESCRIPTION
This will save on memory usage in the cache.