### PR TITLE
Add NewWithClients function

### DIFF
--- a/client/cache.go
+++ b/client/cache.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
-	"k8s.io/klog"
+	klog "k8s.io/klog/v2"
 )
 
 var ErrNoCacheEntry = errors.New("there was no populated cache entry")

--- a/client/cache.go
+++ b/client/cache.go
@@ -62,7 +62,7 @@ func (l *lockedGVR) isExpired() bool {
 
 type objectCache struct {
 	cache           *sync.Map
-	discoveryClient *discovery.DiscoveryClient
+	discoveryClient discovery.DiscoveryInterface
 	// gvkToGVRCache is used as a cache of GVK to GVR mappings. The cache entries automatically expire after 10 minutes.
 	gvkToGVRCache *sync.Map
 	options       ObjectCacheOptions
@@ -81,7 +81,7 @@ type ObjectCacheOptions struct {
 }
 
 // NewObjectCache will create an object cache with the input discovery client.
-func NewObjectCache(discoveryClient *discovery.DiscoveryClient, options ObjectCacheOptions) ObjectCache {
+func NewObjectCache(discoveryClient discovery.DiscoveryInterface, options ObjectCacheOptions) ObjectCache {
 	if options.GVKToGVRCacheTTL == 0 {
 		options.GVKToGVRCacheTTL = 10 * time.Minute
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/watch"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
+	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )

--- a/client/client_example_test.go
+++ b/client/client_example_test.go
@@ -204,7 +204,6 @@ func ExampleNewControllerRuntimeSource() {
 		For(&corev1.ConfigMap{}).
 		WatchesRawSource(sourceChan, &handler.EnqueueRequestForObject{}).
 		Complete(&ctrlRuntimeReconciler{})
-
 	if err != nil {
 		panic(err)
 	}

--- a/client/client_example_test.go
+++ b/client/client_example_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog"
+	klog "k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	k8s.io/api v0.29.5
 	k8s.io/apimachinery v0.29.5
 	k8s.io/client-go v0.29.5
-	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.120.1
 	sigs.k8s.io/controller-runtime v0.17.5
 )
 
@@ -63,7 +63,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.5 // indirect
 	k8s.io/component-base v0.29.5 // indirect
-	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a // indirect
 	k8s.io/utils v0.0.0-20240502163921-fe8a2dddb1d0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
@@ -162,8 +161,6 @@ k8s.io/client-go v0.29.5 h1:nlASXmPQy190qTteaVP31g3c/wi2kycznkTP7Sv1zPc=
 k8s.io/client-go v0.29.5/go.mod h1:aY5CnqUUvXYccJhm47XHoPcRyX6vouHdIBHaKZGTbK4=
 k8s.io/component-base v0.29.5 h1:Ptj8AzG+p8c2a839XriHwxakDpZH9uvIgYz+o1agjg8=
 k8s.io/component-base v0.29.5/go.mod h1:9nBUoPxW/yimISIgAG7sJDrUGJlu7t8HnDafIrOdU8Q=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.120.1 h1:QXU6cPEOIslTGvZaXvFWiP9VKyeet3sawzTOvdXb4Vw=
 k8s.io/klog/v2 v2.120.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a h1:zD1uj3Jf+mD4zmA7W+goE5TxDkI7OGJjBNBzq5fJtLA=


### PR DESCRIPTION
This allows a consumer of the package to not store/use a rest.Config to create a DynamicWatcher, if they already have dynamic and discovery clients.

Internally, this also changes the stored DiscoveryClient in the object cache to use an interface, rather than a specific struct, which helps provide some flexibility to users (for example, for testing).

This PR also updates klog to a current `v2` version, which allows for more user configuration.