### PR TITLE
Address `oauth2` vuln

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      gomod:
+        patterns:
+          - "*"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Test Coverage and Report Generation
       run: |
-        make test-coverage | tee report_unit.json
+        make test-coverage
         make gosec-scan
         cat gosec.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@
 
 .go/
 bin/
+report_*.json
 gosec.json
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ lint:
 ############################################################
 
 .PHONY: test
-test: envtest
-	 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TESTARGS) ./...
+test: e2e-dependencies envtest
+	 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GINKGO) $(TESTARGS) ./...
 
 .PHONY: test-coverage
-test-coverage: TESTARGS = -v -json -cover -covermode=atomic -coverprofile=coverage.out
+test-coverage: TESTARGS = -v --json-report=report_unit.json --cover --covermode=atomic --coverprofile=coverage.out
 test-coverage: test
 
 .PHONY: gosec

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -5,7 +5,7 @@
 # https://github.com/kubernetes-sigs/controller-tools/releases/latest
 CONTROLLER_GEN_VERSION := v0.16.3
 # https://github.com/kubernetes-sigs/kustomize/releases/latest
-KUSTOMIZE_VERSION := v5.4.3
+KUSTOMIZE_VERSION := v5.6.0
 # https://github.com/golangci/golangci-lint/releases/latest
 GOLANGCI_VERSION := v1.52.2
 # https://github.com/mvdan/gofumpt/releases/latest

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -7,13 +7,13 @@ CONTROLLER_GEN_VERSION := v0.16.3
 # https://github.com/kubernetes-sigs/kustomize/releases/latest
 KUSTOMIZE_VERSION := v5.6.0
 # https://github.com/golangci/golangci-lint/releases/latest
-GOLANGCI_VERSION := v1.52.2
+GOLANGCI_VERSION := v1.64.8
 # https://github.com/mvdan/gofumpt/releases/latest
 GOFUMPT_VERSION := v0.7.0
 # https://github.com/daixiang0/gci/releases/latest
-GCI_VERSION := v0.13.5
+GCI_VERSION := v0.13.6
 # https://github.com/securego/gosec/releases/latest
-GOSEC_VERSION := v2.21.3
+GOSEC_VERSION := v2.22.2
 # https://github.com/kubernetes-sigs/kubebuilder/releases/latest
 KBVERSION := 3.15.1
 # https://github.com/kubernetes/kubernetes/releases/latest

--- a/build/common/config/.golangci.yml
+++ b/build/common/config/.golangci.yml
@@ -24,6 +24,7 @@ run:
 linters:
   enable-all: true
   disable:
+    - mnd  # Disabled as tech debt: Magic number detection
     - bodyclose
     # Fails due to  Can't run linter goanalysis_metalinter: goanalysis_metalinter:
     # contextcheck: package \"client\" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory

--- a/client/cache.go
+++ b/client/cache.go
@@ -328,13 +328,13 @@ func (o *objectCache) GVKToGVR(gvk schema.GroupVersionKind) (ScopedGVR, error) {
 
 // Clear will entirely clear the cache.
 func (o *objectCache) Clear() {
-	o.cache.Range(func(key, value any) bool {
+	o.cache.Range(func(key, _ any) bool {
 		o.cache.Delete(key)
 
 		return true
 	})
 
-	o.gvkToGVRCache.Range(func(key, value any) bool {
+	o.gvkToGVRCache.Range(func(key, _ any) bool {
 		o.gvkToGVRCache.Delete(key)
 
 		return true

--- a/client/client.go
+++ b/client/client.go
@@ -276,7 +276,6 @@ func (d *dynamicWatcher) Start(ctx context.Context) error {
 	d.started = true
 	close(d.startedChan)
 
-	//nolint: revive
 	for d.processNextWorkItem(ctx) {
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -131,17 +131,14 @@ func getDynamicWatcher(ctx context.Context, reconcilerObj Reconciler, options *O
 
 var _ = Describe("Test a client without watch permissions", Ordered, func() {
 	var (
-		ctxTest       context.Context
-		dynWatcher    DynamicWatcher
-		reconcilerObj *reconciler
-		watcher       *corev1.ConfigMap
-		watched       *corev1.ConfigMap
+		ctxTest, cancelCtxTest = context.WithCancel(ctx)
+		dynWatcher             DynamicWatcher
+		reconcilerObj          *reconciler
+		watcher                *corev1.ConfigMap
+		watched                *corev1.ConfigMap
 	)
 
 	BeforeAll(func() {
-		var cancelCtxTest context.CancelFunc
-		ctxTest, cancelCtxTest = context.WithCancel(ctx)
-
 		DeferCleanup(func() { cancelCtxTest() })
 
 		watcher = &corev1.ConfigMap{
@@ -279,18 +276,15 @@ var _ = Describe("Test a client without watch permissions", Ordered, func() {
 
 var _ = Describe("Test the client", Ordered, Serial, func() {
 	var (
-		ctxTest        context.Context
-		dynamicWatcher DynamicWatcher
-		reconcilerObj  *reconciler
-		watched        []k8sObject
-		watchedObjIDs  []ObjectIdentifier
-		watcher        *corev1.ConfigMap
+		ctxTest, cancelCtxTest = context.WithCancel(ctx)
+		dynamicWatcher         DynamicWatcher
+		reconcilerObj          *reconciler
+		watched                []k8sObject
+		watchedObjIDs          []ObjectIdentifier
+		watcher                *corev1.ConfigMap
 	)
 
 	BeforeAll(func() {
-		var cancelCtxTest context.CancelFunc
-		ctxTest, cancelCtxTest = context.WithCancel(ctx)
-
 		DeferCleanup(func() { cancelCtxTest() })
 
 		reconcilerObj = &reconciler{
@@ -472,24 +466,21 @@ var _ = Describe("Test the client", Ordered, Serial, func() {
 		_, err = k8sClient.CoreV1().Secrets(namespace).Update(ctxTest, watchedSecret, metav1.UpdateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		Consistently(reconcilerObj.ResultsChan, "3s").Should(HaveLen(0))
+		Consistently(reconcilerObj.ResultsChan, "3s").Should(BeEmpty())
 	})
 })
 
 var _ = Describe("Test the client with the initial reconcile is disabled", Ordered, func() {
 	var (
-		ctxTest        context.Context
-		dynamicWatcher DynamicWatcher
-		reconcilerObj  *reconciler
-		watched        []k8sObject
-		watchedObjIDs  []ObjectIdentifier
-		watcher        *corev1.ConfigMap
+		ctxTest, cancelCtxTest = context.WithCancel(ctx)
+		dynamicWatcher         DynamicWatcher
+		reconcilerObj          *reconciler
+		watched                []k8sObject
+		watchedObjIDs          []ObjectIdentifier
+		watcher                *corev1.ConfigMap
 	)
 
 	BeforeAll(func() {
-		var cancelCtxTest context.CancelFunc
-		ctxTest, cancelCtxTest = context.WithCancel(ctx)
-
 		DeferCleanup(func() { cancelCtxTest() })
 
 		reconcilerObj = &reconciler{
@@ -530,7 +521,7 @@ var _ = Describe("Test the client with the initial reconcile is disabled", Order
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Checking that the reconciler was called during the initial list")
-		Consistently(reconcilerObj.ResultsChan, "5s").Should(HaveLen(0))
+		Consistently(reconcilerObj.ResultsChan, "5s").Should(BeEmpty())
 
 		By("Updating the watched object")
 		watchedSecret := watched[0].(*corev1.Secret)
@@ -545,14 +536,13 @@ var _ = Describe("Test the client with the initial reconcile is disabled", Order
 
 var _ = Describe("Test the client clean up", Ordered, func() {
 	var (
-		watcherID      ObjectIdentifier
-		dynamicWatcher DynamicWatcher
-		reconcilerObj  *reconciler
+		testCtx, testCtxCancel = context.WithCancel(ctx)
+		watcherID              ObjectIdentifier
+		dynamicWatcher         DynamicWatcher
+		reconcilerObj          *reconciler
 	)
 
 	BeforeAll(func() {
-		testCtx, testCtxCancel := context.WithCancel(ctx)
-
 		DeferCleanup(func() { testCtxCancel() })
 
 		reconcilerObj = &reconciler{
@@ -676,16 +666,13 @@ var _ = Describe("Test the client clean up", Ordered, func() {
 
 var _ = Describe("Test the client clean up", Ordered, func() {
 	var (
-		ctxTest        context.Context
-		cancelCtxTest  context.CancelFunc
-		dynamicWatcher DynamicWatcher
-		watched        []k8sObject
-		watcher        *corev1.ConfigMap
+		ctxTest, cancelCtxTest = context.WithCancel(ctx)
+		dynamicWatcher         DynamicWatcher
+		watched                []k8sObject
+		watcher                *corev1.ConfigMap
 	)
 
 	BeforeAll(func() {
-		ctxTest, cancelCtxTest = context.WithCancel(ctx)
-
 		DeferCleanup(func() {
 			// The test should cancel the context, but this ensures it is cancelled during a failure
 			cancelCtxTest()
@@ -827,7 +814,6 @@ var _ = Describe("Test dynamicWatcher.reconcileHandler", Serial, func() {
 		dynWatcher.Queue.Add(obj)
 
 		go func() {
-			//nolint: revive
 			for dynWatcher.processNextWorkItem(ctx) {
 			}
 		}()
@@ -865,7 +851,6 @@ var _ = Describe("Test dynamicWatcher.reconcileHandler", Serial, func() {
 		dynWatcher.Queue.Add(obj)
 
 		go func() {
-			//nolint: revive
 			for dynWatcher.processNextWorkItem(ctx) {
 			}
 		}()
@@ -903,7 +888,6 @@ var _ = Describe("Test dynamicWatcher.reconcileHandler", Serial, func() {
 		dynWatcher.Queue.Add(obj)
 
 		go func() {
-			//nolint: revive
 			for dynWatcher.processNextWorkItem(ctx) {
 			}
 		}()
@@ -975,18 +959,15 @@ var _ = Describe("Test dynamicWatcher not started", func() {
 
 var _ = Describe("Test dynamicWatcher cache disabled errors", Ordered, func() {
 	var (
-		ctxTest        context.Context
-		dynamicWatcher DynamicWatcher
-		reconcilerObj  *reconciler
-		watched        []k8sObject
-		watcher        *corev1.ConfigMap
-		watcherID      ObjectIdentifier
+		ctxTest, cancelCtxTest = context.WithCancel(ctx)
+		dynamicWatcher         DynamicWatcher
+		reconcilerObj          *reconciler
+		watched                []k8sObject
+		watcher                *corev1.ConfigMap
+		watcherID              ObjectIdentifier
 	)
 
 	BeforeAll(func() {
-		var cancelCtxTest context.CancelFunc
-		ctxTest, cancelCtxTest = context.WithCancel(ctx)
-
 		DeferCleanup(func() { cancelCtxTest() })
 
 		reconcilerObj = &reconciler{
@@ -1041,18 +1022,15 @@ var _ = Describe("Test dynamicWatcher cache disabled errors", Ordered, func() {
 
 var _ = Describe("Test the client query API", Ordered, func() {
 	var (
-		ctxTest        context.Context
-		dynamicWatcher DynamicWatcher
-		reconcilerObj  *reconciler
-		watched        []k8sObject
-		watcher        *corev1.ConfigMap
-		watcherID      ObjectIdentifier
+		ctxTest, cancelCtxTest = context.WithCancel(ctx)
+		dynamicWatcher         DynamicWatcher
+		reconcilerObj          *reconciler
+		watched                []k8sObject
+		watcher                *corev1.ConfigMap
+		watcherID              ObjectIdentifier
 	)
 
 	BeforeAll(func() {
-		var cancelCtxTest context.CancelFunc
-		ctxTest, cancelCtxTest = context.WithCancel(ctx)
-
 		DeferCleanup(func() { cancelCtxTest() })
 
 		reconcilerObj = &reconciler{

--- a/client/source_test.go
+++ b/client/source_test.go
@@ -29,18 +29,15 @@ func (r *controllerRuntimeReconciler) Reconcile(_ context.Context, _ reconcile.R
 
 var _ = Describe("Test the controller-runtime source wrapper", func() {
 	var (
-		ctxTest               context.Context
-		cancelCtxTest         context.CancelFunc
-		dynamicWatcher        DynamicWatcher
-		ctrlRuntimeReconciler controllerRuntimeReconciler
-		watched               []k8sObject
-		watchedObjIDs         []ObjectIdentifier
-		watcher               *corev1.ConfigMap
+		ctxTest, cancelCtxTest = context.WithCancel(ctx)
+		dynamicWatcher         DynamicWatcher
+		ctrlRuntimeReconciler  controllerRuntimeReconciler
+		watched                []k8sObject
+		watchedObjIDs          []ObjectIdentifier
+		watcher                *corev1.ConfigMap
 	)
 
 	BeforeEach(func() {
-		ctxTest, cancelCtxTest = context.WithCancel(ctx)
-
 		ctrlRuntimeReconciler = controllerRuntimeReconciler{}
 		reconciler, sourceChan := NewControllerRuntimeSource()
 		watcher, watched, dynamicWatcher = getDynamicWatcher(ctxTest, reconciler, nil)

--- a/client/suite_test.go
+++ b/client/suite_test.go
@@ -27,8 +27,7 @@ var (
 	k8sClient   *kubernetes.Clientset
 	noWatchUser *envtest.AuthenticatedUser
 	testEnv     *envtest.Environment
-	ctx         context.Context
-	cancel      context.CancelFunc
+	ctx, cancel = context.WithCancel(context.TODO())
 )
 
 func TestClient(t *testing.T) {
@@ -60,8 +59,6 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = kubernetes.NewForConfig(k8sConfig)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
-
-	ctx, cancel = context.WithCancel(context.TODO())
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 	_, err = k8sClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stolostron/kubernetes-dependency-watches
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0
@@ -52,7 +52,7 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 	golang.org/x/net v0.33.0 // indirect
-	golang.org/x/oauth2 v0.21.0 // indirect
+	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
-golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
-golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.27.0 h1:da9Vo7/tDv5RH/7nZDz1eMGS/q1Vv1N/7FCrBhI9I3M=
+golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Address CVE-2025-22868

Also:
- Adds Dependabot
- Bumps to Go v1.23
- Uses Ginkgo to run the test

It feels like there's an overuse/misuse of `ctx` here in the tests that I poked at a little bit, but as long as the changes here pass updating the context seemed to be beyond this PR.