### PR TITLE
Fix the `k8s` dependabot pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,10 @@ updates:
     groups:
       gomod-k8s.io:
         patterns:
+          - "k8s.io/*"
           - "*.k8s.io/*"
         update-types:
           - patch
       gomod:
         patterns:
           - "*"
-        exclude-patterns:
-          - "*.k8s.io/*"


### PR DESCRIPTION
Followup to:
- #43 
- #41 
- #38 

Third time's the charm! 😂 I realized the `*.k8s.io` pattern had a dot in the beginning, so it wasn't actually excluding `k8s.io` packages...