### PR TITLE
Return unwatchable resources with an error

### DIFF
--- a/client/cache.go
+++ b/client/cache.go
@@ -292,31 +292,44 @@ func (o *objectCache) GVKToGVR(gvk schema.GroupVersionKind) (ScopedGVR, error) {
 		return ScopedGVR{}, err
 	}
 
+	var firstUnwatchable ScopedGVR
+
 	for _, apiRes := range resources.APIResources {
 		if apiRes.Kind == gvk.Kind {
+			gvr := ScopedGVR{
+				GroupVersionResource: schema.GroupVersionResource{
+					Group:    gvk.GroupVersion().Group,
+					Version:  gvk.GroupVersion().Version,
+					Resource: apiRes.Name,
+				},
+				Namespaced: apiRes.Namespaced,
+			}
+
 			if !strings.Contains(apiRes.Verbs.String(), "watch") {
 				klog.V(2).Infof("Excluding API resource because it does not support watch: %v", apiRes)
+
+				if firstUnwatchable.Resource == "" {
+					firstUnwatchable = gvr
+				}
 
 				continue
 			}
 
 			klog.V(2).Infof("Found the API resource: %v", apiRes)
 
-			gv := gvk.GroupVersion()
-
-			gvr := ScopedGVR{
-				GroupVersionResource: schema.GroupVersionResource{
-					Group:    gv.Group,
-					Version:  gv.Version,
-					Resource: apiRes.Name,
-				},
-				Namespaced: apiRes.Namespaced,
-			}
-
 			lockedGVRObj.gvr = &gvr
 
 			return gvr, nil
 		}
+	}
+
+	if firstUnwatchable.Resource != "" {
+		klog.V(2).Infof("Returning APIResource for the GVK that doesn't support watch as a fallback: %v", gvk)
+
+		lockedGVRObj.gvr = &firstUnwatchable
+		lockedGVRObj.expires = now.Add(o.options.MissingAPIResourceCacheTTL)
+
+		return firstUnwatchable, fmt.Errorf("%v cannot be watched: %w", gvk, ErrResourceUnwatchable)
 	}
 
 	klog.V(2).Infof("The APIResource for the GVK wasn't found: %v", gvk)

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -99,13 +99,14 @@ var _ = Describe("Test the cache", Ordered, func() {
 		Expect(err).To(MatchError(ErrNoVersionedResource))
 	})
 
-	It("Does not convert to GVRs that can't be watched", func() {
-		_, err := cache.GVKToGVR(schema.GroupVersionKind{
+	It("Gives an error when the resource does not support watches", func() {
+		sgvr, err := cache.GVKToGVR(schema.GroupVersionKind{
 			Group:   "authorization.k8s.io",
 			Version: "v1",
 			Kind:    "SubjectAccessReview",
 		})
-		Expect(err).To(MatchError(ErrNoVersionedResource))
+		Expect(err).To(MatchError(ErrResourceUnwatchable))
+		Expect(sgvr.Resource).To(Equal("subjectaccessreviews"))
 	})
 
 	It("Can have its cache cleared", func() {

--- a/client/client.go
+++ b/client/client.go
@@ -32,6 +32,7 @@ var (
 	ErrCacheDisabled        = errors.New("cannot perform this action because the cache is not enabled")
 	ErrInvalidInput         = errors.New("invalid input provided")
 	ErrNoVersionedResource  = errors.New("the resource version was not found")
+	ErrResourceUnwatchable  = errors.New("watch not supported on this resource")
 	ErrQueryBatchInProgress = errors.New(
 		"cannot perform this action; the query batch for this object ID is in progress",
 	)
@@ -370,12 +371,14 @@ func (d *dynamicWatcher) relayWatchEvents(
 
 		w, watchedObjects, err := watchLatest(watchedObject, resource)
 		if err != nil {
-			if k8serrors.IsForbidden(err) || k8serrors.IsUnauthorized(err) {
-				klog.Errorf(
-					"Could not restart a watch request due to the client no longer having access. "+
-						"Cleaning up and starting reconciles for the watchers. Error: %v",
-					err,
-				)
+			// When one of these errors occur, the watch should not be retried
+			if k8serrors.IsForbidden(err) || k8serrors.IsUnauthorized(err) || errors.Is(err, ErrResourceUnwatchable) {
+				if errors.Is(err, ErrResourceUnwatchable) {
+					klog.Errorf("Could not restart a watch request: %v", err)
+				} else {
+					klog.Errorf("Could not restart a watch request due to the client no longer having access. "+
+						"Cleaning up and starting reconciles for the watchers. Error: %v", err)
+				}
 
 				d.lock.Lock()
 				defer d.lock.Unlock()
@@ -744,6 +747,9 @@ func watchLatest(
 	}
 
 	resourceVersion := listResult.GetResourceVersion()
+	if resourceVersion == "" {
+		return nil, listResult.Items, ErrResourceUnwatchable
+	}
 
 	watchStarted := make(chan error, 1)
 	var firstResultSent bool


### PR DESCRIPTION
Before v0.10.1, GVKtoGVR would return the first matching kind for the resource, even if that resource did not support the `watch` API. In v0.10.1, those resources were ignored, likely resulting in a "not found" error being returned.

Now, when no matching resource that supports `watch` is found, it will return the first resource found which matches the kind, along with a special new error: `ErrResourceUnwatchable`. Returning the first matching resource aligns with the "normal" behavior of returning early when a resource does support `watch`, and seems to work better than returning the last matching resource, which is often be a subresource.

This will help users that might want GVKtoGVR without watching an object, and they can specially handle this error when it occurs.

Refs:
 - https://issues.redhat.com/browse/ACM-19965